### PR TITLE
Compatibility Example for Dramatic Doors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,14 @@ repositories {
       includeModule("com.terraformersmc", "modmenu")
     }
   }
+  exclusiveContent {
+    forRepository {
+      maven("https://api.modrinth.com/maven")
+    }
+    filter {
+      includeGroup("maven.modrinth")
+    }
+  }
 }
 
 dependencies {
@@ -70,6 +78,9 @@ dependencies {
   implementation("org.checkerframework:checker-qual:3.23.0")
 
   modRuntimeOnly("com.terraformersmc:modmenu:4.0.5")
+
+  // Compat
+  modCompileOnly("maven.modrinth:dramatic-doors:1.19.2-3.1.3")
 }
 
 tasks {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.sapphic"
-version = "1.9.4+1.20"
+version = "1.9.4+1.20+ddcompat"
 
 if ("CI" in System.getenv()) {
   version = "$version-${versioning.info.build}"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,15 @@ repositories {
       includeModule("com.terraformersmc", "modmenu")
     }
   }
+  exclusiveContent {
+    forRepository {
+      maven("https://repo.sleeping.town/")
+    }
+
+    filter {
+      includeModule("folk.sisby", "kaleido-config")
+    }
+  }
 }
 
 dependencies {
@@ -63,8 +72,7 @@ dependencies {
   modImplementation(include(fabricApi.module("fabric-api-base", "0.58.0+1.19"))!!)
   modImplementation(include(fabricApi.module("fabric-networking-api-v1", "0.58.0+1.19"))!!)
 
-  implementation(include("com.electronwill.night-config:core:3.6.5")!!)
-  implementation(include("com.electronwill.night-config:toml:3.6.5")!!)
+  implementation(include("folk.sisby:kaleido-config:0.3.1+1.3.2")!!)
 
   implementation("org.jetbrains:annotations:23.0.0")
   implementation("org.checkerframework:checker-qual:3.23.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import java.time.Instant
 
 plugins {
-  id(/*net.fabricmc.*/ "fabric-loom") version "0.12.55"
+  id(/*net.fabricmc.*/ "fabric-loom") version "1.9.+"
   id("io.github.juuxel.loom-quiltflower") version "1.7.3"
   id("net.nemerosa.versioning") version "3.0.0"
   id("org.gradle.signing")
@@ -59,7 +59,7 @@ repositories {
 }
 
 dependencies {
-  minecraft("com.mojang:minecraft:1.19")
+  minecraft("com.mojang:minecraft:1.19.2")
 
   mappings(loom.layered {
     officialMojangMappings {
@@ -67,17 +67,15 @@ dependencies {
     }
   })
 
-  modImplementation("net.fabricmc:fabric-loader:0.14.8")
+  modImplementation("net.fabricmc:fabric-loader:0.16.9")
 
-  modImplementation(include(fabricApi.module("fabric-api-base", "0.58.0+1.19"))!!)
-  modImplementation(include(fabricApi.module("fabric-networking-api-v1", "0.58.0+1.19"))!!)
+  modImplementation(include(fabricApi.module("fabric-api-base", "0.77.0+1.19.2"))!!)
+  modImplementation(include(fabricApi.module("fabric-networking-api-v1", "0.77.0+1.19.2"))!!)
 
   implementation(include("folk.sisby:kaleido-config:0.3.1+1.3.2")!!)
 
   implementation("org.jetbrains:annotations:23.0.0")
   implementation("org.checkerframework:checker-qual:3.23.0")
-
-  modRuntimeOnly("com.terraformersmc:modmenu:4.0.5")
 }
 
 tasks {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=97a52d145762adc241bad7fd18289bf7f6801e08ece6badf80402fe2b9f250b1
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionSha256Sum=7c3ad722e9b0ce8205b91560fd6ce8296ac3eadf065672242fd73c06b8eeb6ee
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=7c3ad722e9b0ce8205b91560fd6ce8296ac3eadf065672242fd73c06b8eeb6ee
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionSha256Sum=8d97a97984f6cbd2b85fe4c60a743440a347544bf18818048e611f5288d46c94
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/dev/sapphic/couplings/Couplings.java
+++ b/src/main/java/dev/sapphic/couplings/Couplings.java
@@ -16,9 +16,6 @@
 
 package dev.sapphic.couplings;
 
-import com.electronwill.nightconfig.core.ConfigSpec;
-import com.electronwill.nightconfig.core.file.CommentedFileConfig;
-import com.electronwill.nightconfig.core.io.ParsingException;
 import com.google.common.base.Preconditions;
 import io.netty.buffer.Unpooled;
 import net.fabricmc.api.ModInitializer;
@@ -38,74 +35,33 @@ public final class Couplings implements ModInitializer {
   static final ResourceLocation CLIENT_CONFIG = new ResourceLocation("couplings", "client_config");
   static final ResourceLocation SERVER_CONFIG = new ResourceLocation("couplings", "server_config");
 
-  static final boolean IGNORE_SNEAKING;
-  static final boolean COUPLE_DOORS;
-  static final boolean COUPLE_FENCE_GATES;
-  static final boolean COUPLE_TRAPDOORS;
-
-  static {
-    final var configs = FabricLoader.getInstance().getConfigDir();
-    final var config = CommentedFileConfig.of(configs.resolve("couplings.toml"));
-
-    try { 
-      config.load();
-    } catch (final ParsingException e) {
-      LogManager.getLogger().warn(e.getMessage());
-    }
-
-    final var ignoreSneaking = "ignore_sneaking";
-    final var coupleDoors = "couple_doors";
-    final var coupleFenceGates = "couple_fence_gates";
-    final var coupleTrapdoors = "couple_trapdoors";
-
-    final var spec = new ConfigSpec();
-
-    spec.define(ignoreSneaking, true);
-    spec.define(coupleDoors, true);
-    spec.define(coupleFenceGates, true);
-    spec.define(coupleTrapdoors, true);
-
-    spec.correct(config);
-
-    config.setComment(ignoreSneaking, "Couple regardless of whether the player is sneaking");
-    config.setComment(coupleDoors, "Couple doors with opposing hinges");
-    config.setComment(coupleFenceGates, "Couple fence gates above and below on the same axis");
-    config.setComment(coupleTrapdoors, "Couple trapdoors along either sides and opposing");
-
-    config.save();
-
-    IGNORE_SNEAKING = config.get(ignoreSneaking);
-    COUPLE_DOORS = config.get(coupleDoors);
-    COUPLE_FENCE_GATES = config.get(coupleFenceGates);
-    COUPLE_TRAPDOORS = config.get(coupleTrapdoors);
-
-    if (!COUPLE_DOORS || !COUPLE_FENCE_GATES || !COUPLE_TRAPDOORS) {
-      LogManager.getLogger().warn("No features are enabled, this could be a bug!");
-    }
-  }
+  public static final CouplingsConfig CONFIG = CouplingsConfig.createToml(FabricLoader.getInstance().getConfigDir(), "", "couplings", CouplingsConfig.class);
 
   public static boolean ignoresSneaking(final Player player) {
     if (player instanceof CouplingsPlayer) {
       return CouplingsPlayer.ignoresSneaking(player);
     }
 
-    return IGNORE_SNEAKING;
+    return CONFIG.ignoreSneaking;
   }
 
   public static boolean couplesDoors(final Level level) {
-    return level.isClientSide() ? CouplingsClient.serverCouplesDoors() : COUPLE_DOORS;
+    return level.isClientSide() ? CouplingsClient.serverCouplesDoors() : CONFIG.coupleDoors;
   }
 
   public static boolean couplesFenceGates(final Level level) {
-    return level.isClientSide() ? CouplingsClient.serverCouplesFenceGates() : COUPLE_FENCE_GATES;
+    return level.isClientSide() ? CouplingsClient.serverCouplesFenceGates() : CONFIG.coupleFenceGates;
   }
 
   public static boolean couplesTrapdoors(final Level level) {
-    return level.isClientSide() ? CouplingsClient.serverCouplesTrapdoors() : COUPLE_TRAPDOORS;
+    return level.isClientSide() ? CouplingsClient.serverCouplesTrapdoors() : CONFIG.coupleTrapdoors;
   }
 
   @Override
   public void onInitialize() {
+    if (!CONFIG.coupleDoors || !CONFIG.coupleFenceGates || !CONFIG.coupleTrapdoors) {
+      LogManager.getLogger().warn("No features are enabled, this could be a bug!");
+    }
     ServerPlayNetworking.registerGlobalReceiver(
         CLIENT_CONFIG,
         (server, player, listener, buf, sender) -> {
@@ -122,9 +78,9 @@ public final class Couplings implements ModInitializer {
         (listener, sender, server) -> {
           var couplings = 0b000;
 
-          couplings |= (COUPLE_DOORS ? 1 : 0) << 2;
-          couplings |= (COUPLE_FENCE_GATES ? 1 : 0) << 1;
-          couplings |= COUPLE_TRAPDOORS ? 1 : 0;
+          couplings |= (CONFIG.coupleDoors ? 1 : 0) << 2;
+          couplings |= (CONFIG.coupleFenceGates ? 1 : 0) << 1;
+          couplings |= CONFIG.coupleTrapdoors ? 1 : 0;
 
           final var buffer =
               Unpooled.buffer(Byte.BYTES, Byte.BYTES).writeByte(couplings).asReadOnly();

--- a/src/main/java/dev/sapphic/couplings/Couplings.java
+++ b/src/main/java/dev/sapphic/couplings/Couplings.java
@@ -42,24 +42,24 @@ public final class Couplings implements ModInitializer {
       return CouplingsPlayer.ignoresSneaking(player);
     }
 
-    return CONFIG.ignoreSneaking;
+    return CONFIG.ignoreSneaking.value();
   }
 
   public static boolean couplesDoors(final Level level) {
-    return level.isClientSide() ? CouplingsClient.serverCouplesDoors() : CONFIG.coupleDoors;
+    return level.isClientSide() ? CouplingsClient.serverCouplesDoors() : CONFIG.coupleDoors.value();
   }
 
   public static boolean couplesFenceGates(final Level level) {
-    return level.isClientSide() ? CouplingsClient.serverCouplesFenceGates() : CONFIG.coupleFenceGates;
+    return level.isClientSide() ? CouplingsClient.serverCouplesFenceGates() : CONFIG.coupleFenceGates.value();
   }
 
   public static boolean couplesTrapdoors(final Level level) {
-    return level.isClientSide() ? CouplingsClient.serverCouplesTrapdoors() : CONFIG.coupleTrapdoors;
+    return level.isClientSide() ? CouplingsClient.serverCouplesTrapdoors() : CONFIG.coupleTrapdoors.value();
   }
 
   @Override
   public void onInitialize() {
-    if (!CONFIG.coupleDoors || !CONFIG.coupleFenceGates || !CONFIG.coupleTrapdoors) {
+    if (!CONFIG.coupleDoors.value() || !CONFIG.coupleFenceGates.value() || !CONFIG.coupleTrapdoors.value()) {
       LogManager.getLogger().warn("No features are enabled, this could be a bug!");
     }
     ServerPlayNetworking.registerGlobalReceiver(
@@ -78,9 +78,9 @@ public final class Couplings implements ModInitializer {
         (listener, sender, server) -> {
           var couplings = 0b000;
 
-          couplings |= (CONFIG.coupleDoors ? 1 : 0) << 2;
-          couplings |= (CONFIG.coupleFenceGates ? 1 : 0) << 1;
-          couplings |= CONFIG.coupleTrapdoors ? 1 : 0;
+          couplings |= (CONFIG.coupleDoors.value() ? 1 : 0) << 2;
+          couplings |= (CONFIG.coupleFenceGates.value() ? 1 : 0) << 1;
+          couplings |= CONFIG.coupleTrapdoors.value() ? 1 : 0;
 
           final var buffer =
               Unpooled.buffer(Byte.BYTES, Byte.BYTES).writeByte(couplings).asReadOnly();

--- a/src/main/java/dev/sapphic/couplings/CouplingsClient.java
+++ b/src/main/java/dev/sapphic/couplings/CouplingsClient.java
@@ -64,7 +64,7 @@ public final class CouplingsClient implements ClientModInitializer {
 
     ClientPlayConnectionEvents.JOIN.register(
         (listener, sender, minecraft) -> {
-          final var clientConfig = Couplings.CONFIG.ignoreSneaking ? 1 : 0;
+          final var clientConfig = Couplings.CONFIG.ignoreSneaking.value() ? 1 : 0;
 
           ClientPlayNetworking.send(
               Couplings.CLIENT_CONFIG,

--- a/src/main/java/dev/sapphic/couplings/CouplingsClient.java
+++ b/src/main/java/dev/sapphic/couplings/CouplingsClient.java
@@ -64,7 +64,7 @@ public final class CouplingsClient implements ClientModInitializer {
 
     ClientPlayConnectionEvents.JOIN.register(
         (listener, sender, minecraft) -> {
-          final var clientConfig = Couplings.IGNORE_SNEAKING ? 1 : 0;
+          final var clientConfig = Couplings.CONFIG.ignoreSneaking ? 1 : 0;
 
           ClientPlayNetworking.send(
               Couplings.CLIENT_CONFIG,

--- a/src/main/java/dev/sapphic/couplings/CouplingsConfig.java
+++ b/src/main/java/dev/sapphic/couplings/CouplingsConfig.java
@@ -5,7 +5,7 @@ import folk.sisby.kaleido.lib.quiltconfig.api.annotations.Comment;
 import folk.sisby.kaleido.lib.quiltconfig.api.annotations.SerializedNameConvention;
 import folk.sisby.kaleido.lib.quiltconfig.api.metadata.NamingSchemes;
 
-@SerializedNameConvention(NamingSchemes.LOWER_CAMEL_CASE)
+@SerializedNameConvention(NamingSchemes.SNAKE_CASE)
 public class CouplingsConfig extends WrappedConfig {
     @Comment("Couple regardless of whether the player is sneaking")
     boolean ignoreSneaking;

--- a/src/main/java/dev/sapphic/couplings/CouplingsConfig.java
+++ b/src/main/java/dev/sapphic/couplings/CouplingsConfig.java
@@ -1,0 +1,18 @@
+package dev.sapphic.couplings;
+
+import folk.sisby.kaleido.api.WrappedConfig;
+import folk.sisby.kaleido.lib.quiltconfig.api.annotations.Comment;
+import folk.sisby.kaleido.lib.quiltconfig.api.annotations.SerializedNameConvention;
+import folk.sisby.kaleido.lib.quiltconfig.api.metadata.NamingSchemes;
+
+@SerializedNameConvention(NamingSchemes.LOWER_CAMEL_CASE)
+public class CouplingsConfig extends WrappedConfig {
+    @Comment("Couple regardless of whether the player is sneaking")
+    boolean ignoreSneaking;
+    @Comment("Couple doors with opposing hinges")
+    boolean coupleDoors;
+    @Comment("Couple fence gates above and below on the same axis")
+    boolean coupleFenceGates;
+    @Comment("Couple trapdoors along either sides and opposing")
+    boolean coupleTrapdoors;
+}

--- a/src/main/java/dev/sapphic/couplings/CouplingsConfig.java
+++ b/src/main/java/dev/sapphic/couplings/CouplingsConfig.java
@@ -1,18 +1,19 @@
 package dev.sapphic.couplings;
 
-import folk.sisby.kaleido.api.WrappedConfig;
+import folk.sisby.kaleido.api.ReflectiveConfig;
 import folk.sisby.kaleido.lib.quiltconfig.api.annotations.Comment;
 import folk.sisby.kaleido.lib.quiltconfig.api.annotations.SerializedNameConvention;
 import folk.sisby.kaleido.lib.quiltconfig.api.metadata.NamingSchemes;
+import folk.sisby.kaleido.lib.quiltconfig.api.values.TrackedValue;
 
 @SerializedNameConvention(NamingSchemes.SNAKE_CASE)
-public class CouplingsConfig extends WrappedConfig {
+public class CouplingsConfig extends ReflectiveConfig {
     @Comment("Couple regardless of whether the player is sneaking")
-    boolean ignoreSneaking = false;
+    public final TrackedValue<Boolean> ignoreSneaking = value(false);
     @Comment("Couple doors with opposing hinges")
-    boolean coupleDoors = true;
+    public final TrackedValue<Boolean>  coupleDoors = value(true);
     @Comment("Couple fence gates above and below on the same axis")
-    boolean coupleFenceGates = true;
+    public final TrackedValue<Boolean>  coupleFenceGates = value(true);
     @Comment("Couple trapdoors along either sides and opposing")
-    boolean coupleTrapdoors = true;
+    public final TrackedValue<Boolean>  coupleTrapdoors = value(true);
 }

--- a/src/main/java/dev/sapphic/couplings/CouplingsConfig.java
+++ b/src/main/java/dev/sapphic/couplings/CouplingsConfig.java
@@ -8,11 +8,11 @@ import folk.sisby.kaleido.lib.quiltconfig.api.metadata.NamingSchemes;
 @SerializedNameConvention(NamingSchemes.SNAKE_CASE)
 public class CouplingsConfig extends WrappedConfig {
     @Comment("Couple regardless of whether the player is sneaking")
-    boolean ignoreSneaking;
+    boolean ignoreSneaking = false;
     @Comment("Couple doors with opposing hinges")
-    boolean coupleDoors;
+    boolean coupleDoors = true;
     @Comment("Couple fence gates above and below on the same axis")
-    boolean coupleFenceGates;
+    boolean coupleFenceGates = true;
     @Comment("Couple trapdoors along either sides and opposing")
-    boolean coupleTrapdoors;
+    boolean coupleTrapdoors = true;
 }

--- a/src/main/java/dev/sapphic/couplings/impl/ShortDoorBlockCoupling.java
+++ b/src/main/java/dev/sapphic/couplings/impl/ShortDoorBlockCoupling.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2022 Chloe Dawn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.sapphic.couplings.impl;
+
+import dev.sapphic.couplings.Couplings;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.DoorBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.DoorHingeSide;
+import net.minecraft.world.level.gameevent.GameEvent;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public final class ShortDoorBlockCoupling {
+  private ShortDoorBlockCoupling() {}
+
+  public static void used(
+      final BlockState state, final Level level, final BlockPos pos, final Player player) {
+    if (Couplings.couplesDoors(level)
+        && (!player.isCrouching() || Couplings.ignoresSneaking(player))) {
+      final var offset = getCoupledDoorPos(state, pos);
+
+      if (level.mayInteract(player, offset)) {
+        final var other = level.getBlockState(offset);
+
+        if (state.getBlock() == other.getBlock()) {
+          final var open = state.getValue(DoorBlock.OPEN);
+
+          if (areCoupled(state, other, open)) {
+            level.setBlock(offset, other.setValue(DoorBlock.OPEN, open), 2);
+            level.gameEvent(player, open ? GameEvent.BLOCK_OPEN : GameEvent.BLOCK_CLOSE, offset);
+          }
+        }
+      }
+    }
+  }
+
+  public static void openStateChanged(
+      final @Nullable Entity entity,
+      final BlockState state,
+      final Level level,
+      final BlockPos pos,
+      final boolean open) {
+    if (Couplings.couplesDoors(level)) {
+      final var offset = getCoupledDoorPos(state, pos);
+      final var other = level.getBlockState(offset);
+
+      if ((state.getBlock() == other.getBlock()) && areCoupled(state, other, open)) {
+        level.setBlock(offset, other.setValue(DoorBlock.OPEN, open), 10);
+        level.gameEvent(entity, open ? GameEvent.BLOCK_OPEN : GameEvent.BLOCK_CLOSE, offset);
+      }
+    }
+  }
+
+  public static void neighborChanged(
+      final BlockState state, final Level level, final BlockPos pos, final boolean powered) {
+    if (Couplings.couplesDoors(level)
+        && (!powered || (level.getBestNeighborSignal(pos) >= Couplings.COUPLING_SIGNAL))) {
+      final var offset = getCoupledDoorPos(state, pos);
+      final var other = level.getBlockState(offset);
+
+      if ((state.getBlock() == other.getBlock()) && areCoupled(state, other, powered)) {
+        level.setBlock(offset, other.setValue(DoorBlock.OPEN, powered), 2);
+        level.gameEvent(null, powered ? GameEvent.BLOCK_OPEN : GameEvent.BLOCK_CLOSE, offset);
+      }
+    }
+  }
+
+  private static boolean areCoupled(
+      final BlockState self, final BlockState other, final boolean open) {
+    return (open != other.getValue(DoorBlock.OPEN))
+        && (self.getValue(DoorBlock.FACING) == other.getValue(DoorBlock.FACING))
+        && (self.getValue(DoorBlock.HINGE) != other.getValue(DoorBlock.HINGE));
+  }
+
+  private static BlockPos getCoupledDoorPos(final BlockState state, final BlockPos pos) {
+    final var facing = state.getValue(DoorBlock.FACING);
+    final var leftHinge = state.getValue(DoorBlock.HINGE) == DoorHingeSide.LEFT;
+
+    return pos.relative(leftHinge ? facing.getClockWise() : facing.getCounterClockWise());
+  }
+}

--- a/src/main/java/dev/sapphic/couplings/impl/TallDoorBlockCoupling.java
+++ b/src/main/java/dev/sapphic/couplings/impl/TallDoorBlockCoupling.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2022 Chloe Dawn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.sapphic.couplings.impl;
+
+import com.fizzware.dramaticdoors.fabric.blocks.TallDoorBlock;
+import dev.sapphic.couplings.Couplings;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.DoorBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.DoorHingeSide;
+import net.minecraft.world.level.gameevent.GameEvent;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public final class TallDoorBlockCoupling {
+  private TallDoorBlockCoupling() {}
+
+  public static void used(
+      final BlockState state, final Level level, final BlockPos pos, final Player player) {
+    if (Couplings.couplesDoors(level)
+        && (!player.isCrouching() || Couplings.ignoresSneaking(player))) {
+      final var offset = getCoupledDoorPos(state, pos);
+
+      if (level.mayInteract(player, offset)) {
+        final var other = level.getBlockState(offset);
+
+        if (state.getBlock() == other.getBlock()) {
+          final var open = state.getValue(DoorBlock.OPEN);
+
+          if (areCoupled(state, other, open)) {
+            level.setBlock(offset, other.setValue(DoorBlock.OPEN, open), 2);
+            level.gameEvent(player, open ? GameEvent.BLOCK_OPEN : GameEvent.BLOCK_CLOSE, offset);
+          }
+        }
+      }
+    }
+  }
+
+  public static void openStateChanged(
+      final @Nullable Entity entity,
+      final BlockState state,
+      final Level level,
+      final BlockPos pos,
+      final boolean open) {
+    if (Couplings.couplesDoors(level)) {
+      final var offset = getCoupledDoorPos(state, pos);
+      final var other = level.getBlockState(offset);
+
+      if ((state.getBlock() == other.getBlock()) && areCoupled(state, other, open)) {
+        level.setBlock(offset, other.setValue(DoorBlock.OPEN, open), 10);
+        level.gameEvent(entity, open ? GameEvent.BLOCK_OPEN : GameEvent.BLOCK_CLOSE, offset);
+      }
+    }
+  }
+
+  public static void neighborChanged(
+      final BlockState state, final Level level, final BlockPos pos, final boolean powered) {
+    if (Couplings.couplesDoors(level)
+        && (!powered || (level.getBestNeighborSignal(pos) >= Couplings.COUPLING_SIGNAL))) {
+      final var offset = getCoupledDoorPos(state, pos);
+      final var other = level.getBlockState(offset);
+
+      if ((state.getBlock() == other.getBlock()) && areCoupled(state, other, powered)) {
+        level.setBlock(offset, other.setValue(DoorBlock.OPEN, powered), 2);
+        level.gameEvent(null, powered ? GameEvent.BLOCK_OPEN : GameEvent.BLOCK_CLOSE, offset);
+      }
+    }
+  }
+
+  private static boolean areCoupled(
+      final BlockState self, final BlockState other, final boolean open) {
+    return (open != other.getValue(DoorBlock.OPEN))
+        && (self.getValue(DoorBlock.FACING) == other.getValue(DoorBlock.FACING))
+        && (self.getValue(TallDoorBlock.THIRD) == other.getValue(TallDoorBlock.THIRD))
+        && (self.getValue(DoorBlock.HINGE) != other.getValue(DoorBlock.HINGE));
+  }
+
+  private static BlockPos getCoupledDoorPos(final BlockState state, final BlockPos pos) {
+    final var facing = state.getValue(DoorBlock.FACING);
+    final var leftHinge = state.getValue(DoorBlock.HINGE) == DoorHingeSide.LEFT;
+
+    return pos.relative(leftHinge ? facing.getClockWise() : facing.getCounterClockWise());
+  }
+}

--- a/src/main/java/dev/sapphic/couplings/mixin/compat/MixinCompatPlugin.java
+++ b/src/main/java/dev/sapphic/couplings/mixin/compat/MixinCompatPlugin.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 Chloe Dawn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.sapphic.couplings.mixin.compat;
+
+import net.fabricmc.loader.api.FabricLoader;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public class MixinCompatPlugin implements IMixinConfigPlugin {
+    @Override
+    public void onLoad(String mixinPackage) {
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        if (mixinClassName.startsWith("dev.sapphic.couplings.mixin.compat.")) {
+            int startModID = mixinClassName.indexOf(".compat.") + ".compat.".length();
+            int endModID  = mixinClassName.indexOf('.', startModID);
+            String modID = mixinClassName.substring(startModID, endModID);
+            return FabricLoader.getInstance().isModLoaded(modID) || FabricLoader.getInstance().isModLoaded(modID.replace("_", "-"));
+        }
+        return true;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    }
+}

--- a/src/main/java/dev/sapphic/couplings/mixin/compat/dramaticdoors/ShortDoorBlockMixin.java
+++ b/src/main/java/dev/sapphic/couplings/mixin/compat/dramaticdoors/ShortDoorBlockMixin.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2022 Chloe Dawn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.sapphic.couplings.mixin.compat.dramaticdoors;
+
+import com.fizzware.dramaticdoors.fabric.blocks.ShortDoorBlock;
+import dev.sapphic.couplings.impl.ShortDoorBlockCoupling;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+@Mixin(ShortDoorBlock.class)
+public class ShortDoorBlockMixin {
+    @Inject(
+            method =
+                    "use("
+                            + "Lnet/minecraft/world/level/block/state/BlockState;"
+                            + "Lnet/minecraft/world/level/Level;"
+                            + "Lnet/minecraft/core/BlockPos;"
+                            + "Lnet/minecraft/world/entity/player/Player;"
+                            + "Lnet/minecraft/world/InteractionHand;"
+                            + "Lnet/minecraft/world/phys/BlockHitResult;"
+                            + ")Lnet/minecraft/world/InteractionResult;",
+            at =
+            @At(
+                    shift = At.Shift.AFTER,
+                    value = "INVOKE",
+                    opcode = Opcodes.INVOKEVIRTUAL,
+                    target =
+                            "Lnet/minecraft/world/level/Level;"
+                                    + "setBlock("
+                                    + "Lnet/minecraft/core/BlockPos;"
+                                    + "Lnet/minecraft/world/level/block/state/BlockState;"
+                                    + "I"
+                                    + ")Z"),
+            require = 1,
+            allow = 1)
+    private void used(
+            final BlockState state,
+            final Level level,
+            final BlockPos pos,
+            final Player player,
+            final InteractionHand hand,
+            final BlockHitResult hit,
+            final CallbackInfoReturnable<InteractionResult> cir) {
+        ShortDoorBlockCoupling.used(state, level, pos, player);
+    }
+
+    @Inject(
+            method =
+                    "setOpen("
+                            + "Lnet/minecraft/world/entity/Entity;"
+                            + "Lnet/minecraft/world/level/Level;"
+                            + "Lnet/minecraft/world/level/block/state/BlockState;"
+                            + "Lnet/minecraft/core/BlockPos;"
+                            + "Z"
+                            + ")V",
+            at =
+            @At(
+                    shift = At.Shift.AFTER,
+                    value = "INVOKE",
+                    opcode = Opcodes.INVOKEVIRTUAL,
+                    target =
+                            "Lcom/fizzware/dramaticdoors/fabric/blocks/ShortDoorBlock;"
+                                    + "playSound("
+                                    + "Lnet/minecraft/world/level/Level;"
+                                    + "Lnet/minecraft/core/BlockPos;"
+                                    + "Z"
+                                    + ")V"),
+            require = 1,
+            allow = 1)
+    private void openStateChanged(
+            final @Nullable Entity entity,
+            final Level level,
+            final BlockState state,
+            final BlockPos pos,
+            final boolean open,
+            final CallbackInfo ci) {
+        ShortDoorBlockCoupling.openStateChanged(entity, state, level, pos, open);
+    }
+
+    @Inject(
+            method =
+                    "neighborChanged("
+                            + "Lnet/minecraft/world/level/block/state/BlockState;"
+                            + "Lnet/minecraft/world/level/Level;"
+                            + "Lnet/minecraft/core/BlockPos;"
+                            + "Lnet/minecraft/world/level/block/Block;"
+                            + "Lnet/minecraft/core/BlockPos;"
+                            + "Z"
+                            + ")V",
+            at =
+            @At(
+                    shift = At.Shift.AFTER,
+                    value = "INVOKE",
+                    opcode = Opcodes.INVOKEVIRTUAL,
+                    target =
+                            "Lnet/minecraft/world/level/Level;"
+                                    + "setBlock("
+                                    + "Lnet/minecraft/core/BlockPos;"
+                                    + "Lnet/minecraft/world/level/block/state/BlockState;"
+                                    + "I"
+                                    + ")Z"),
+            locals = LocalCapture.CAPTURE_FAILHARD
+    )
+    private void neighborChanged(
+            final BlockState state,
+            final Level level,
+            final BlockPos pos,
+            final Block block,
+            final BlockPos offset,
+            final boolean moved,
+            final CallbackInfo ci,
+            final boolean powered) {
+        ShortDoorBlockCoupling.neighborChanged(state, level, pos, powered);
+    }
+}

--- a/src/main/java/dev/sapphic/couplings/mixin/compat/dramaticdoors/ShortDoorBlockMixin.java
+++ b/src/main/java/dev/sapphic/couplings/mixin/compat/dramaticdoors/ShortDoorBlockMixin.java
@@ -90,6 +90,7 @@ public class ShortDoorBlockMixin {
                     target =
                             "Lcom/fizzware/dramaticdoors/fabric/blocks/ShortDoorBlock;"
                                     + "playSound("
+                                    + "Lnet/minecraft/world/entity/Entity;"
                                     + "Lnet/minecraft/world/level/Level;"
                                     + "Lnet/minecraft/core/BlockPos;"
                                     + "Z"

--- a/src/main/java/dev/sapphic/couplings/mixin/compat/dramaticdoors/TallDoorBlockMixin.java
+++ b/src/main/java/dev/sapphic/couplings/mixin/compat/dramaticdoors/TallDoorBlockMixin.java
@@ -91,6 +91,7 @@ public class TallDoorBlockMixin {
                     target =
                             "Lcom/fizzware/dramaticdoors/fabric/blocks/TallDoorBlock;"
                                     + "playSound("
+                                    + "Lnet/minecraft/world/entity/Entity;"
                                     + "Lnet/minecraft/world/level/Level;"
                                     + "Lnet/minecraft/core/BlockPos;"
                                     + "Z"

--- a/src/main/java/dev/sapphic/couplings/mixin/compat/dramaticdoors/TallDoorBlockMixin.java
+++ b/src/main/java/dev/sapphic/couplings/mixin/compat/dramaticdoors/TallDoorBlockMixin.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2022 Chloe Dawn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.sapphic.couplings.mixin.compat.dramaticdoors;
+
+import com.fizzware.dramaticdoors.fabric.blocks.TallDoorBlock;
+import dev.sapphic.couplings.impl.TallDoorBlockCoupling;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+@Mixin(TallDoorBlock.class)
+public class TallDoorBlockMixin {
+    @Inject(
+            method =
+                    "use("
+                            + "Lnet/minecraft/world/level/block/state/BlockState;"
+                            + "Lnet/minecraft/world/level/Level;"
+                            + "Lnet/minecraft/core/BlockPos;"
+                            + "Lnet/minecraft/world/entity/player/Player;"
+                            + "Lnet/minecraft/world/InteractionHand;"
+                            + "Lnet/minecraft/world/phys/BlockHitResult;"
+                            + ")Lnet/minecraft/world/InteractionResult;",
+            at =
+            @At(
+                    shift = At.Shift.AFTER,
+                    value = "INVOKE",
+                    opcode = Opcodes.INVOKEVIRTUAL,
+                    target =
+                            "Lnet/minecraft/world/level/Level;"
+                                    + "setBlock("
+                                    + "Lnet/minecraft/core/BlockPos;"
+                                    + "Lnet/minecraft/world/level/block/state/BlockState;"
+                                    + "I"
+                                    + ")Z"),
+            require = 1,
+            allow = 1
+    )
+    private void used(
+            final BlockState state,
+            final Level level,
+            final BlockPos pos,
+            final Player player,
+            final InteractionHand hand,
+            final BlockHitResult hit,
+            final CallbackInfoReturnable<InteractionResult> cir) {
+        TallDoorBlockCoupling.used(state, level, pos, player);
+    }
+
+    @Inject(
+            method =
+                    "setOpen("
+                            + "Lnet/minecraft/world/entity/Entity;"
+                            + "Lnet/minecraft/world/level/Level;"
+                            + "Lnet/minecraft/world/level/block/state/BlockState;"
+                            + "Lnet/minecraft/core/BlockPos;"
+                            + "Z"
+                            + ")V",
+            at =
+            @At(
+                    shift = At.Shift.AFTER,
+                    value = "INVOKE",
+                    opcode = Opcodes.INVOKEVIRTUAL,
+                    target =
+                            "Lcom/fizzware/dramaticdoors/fabric/blocks/TallDoorBlock;"
+                                    + "playSound("
+                                    + "Lnet/minecraft/world/level/Level;"
+                                    + "Lnet/minecraft/core/BlockPos;"
+                                    + "Z"
+                                    + ")V")
+    )
+    private void openStateChanged(
+            final @Nullable Entity entity,
+            final Level level,
+            final BlockState state,
+            final BlockPos pos,
+            final boolean open,
+            final CallbackInfo ci) {
+        TallDoorBlockCoupling.openStateChanged(entity, state, level, pos, open);
+    }
+
+    @Inject(
+            method =
+                    "neighborChanged("
+                            + "Lnet/minecraft/world/level/block/state/BlockState;"
+                            + "Lnet/minecraft/world/level/Level;"
+                            + "Lnet/minecraft/core/BlockPos;"
+                            + "Lnet/minecraft/world/level/block/Block;"
+                            + "Lnet/minecraft/core/BlockPos;"
+                            + "Z"
+                            + ")V",
+            at =
+            @At(
+                    shift = At.Shift.AFTER,
+                    value = "INVOKE",
+                    opcode = Opcodes.INVOKEVIRTUAL,
+                    target =
+                            "Lnet/minecraft/world/level/Level;"
+                                    + "setBlock("
+                                    + "Lnet/minecraft/core/BlockPos;"
+                                    + "Lnet/minecraft/world/level/block/state/BlockState;"
+                                    + "I"
+                                    + ")Z"),
+            locals = LocalCapture.CAPTURE_FAILHARD
+    )
+    private void neighborChanged(
+            final BlockState state,
+            final Level level,
+            final BlockPos pos,
+            final Block block,
+            final BlockPos offset,
+            final boolean moved,
+            final CallbackInfo ci,
+            final boolean powered) {
+        TallDoorBlockCoupling.neighborChanged(state, level, pos, powered);
+    }
+}

--- a/src/main/resources/mixins/couplings/mixins.json
+++ b/src/main/resources/mixins/couplings/mixins.json
@@ -3,11 +3,14 @@
   "compatibilityLevel": "JAVA_17",
   "required": true,
   "package": "dev.sapphic.couplings.mixin",
+  "plugin": "dev.sapphic.couplings.mixin.compat.MixinCompatPlugin",
   "mixins": [
     "DoorBlockMixin",
     "FenceGateBlockMixin",
     "ServerPlayerMixin",
-    "TrapdoorBlockMixin"
+    "TrapdoorBlockMixin",
+    "compat.dramaticdoors.ShortDoorBlockMixin",
+    "compat.dramaticdoors.TallDoorBlockMixin"
   ],
   "refmap": "mixins/couplings/refmap.json"
 }


### PR DESCRIPTION
Hi hello! This is a compat-fork for [Dramatic Doors](https://modrinth.com/mod/dramatic-doors), an xplat mod that adds 1-block and 3-block high doors.

It doesn't perform any refactors to make the code less long or more repeatable, but it's a decent example for anyone coming to the pull requests tab to learn to do exactly this.

Created in two commits for use in both 1.19.2 and 1.20.1.

This could _technically_  be merged, but the license is permissive and enabling this kind of compatibility could probably be done more generically than this - so I'm perfectly fine leaving it as inspiration and using it myself.