### PR TITLE
Replace nightconfig with kaleido (repackaged quiltconfig)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,7 @@
 import java.time.Instant
 
 plugins {
-  id(/*net.fabricmc.*/ "fabric-loom") version "1.3.2"
-  id("io.github.juuxel.loom-quiltflower") version "1.10.0"
+  id(/*net.fabricmc.*/ "fabric-loom") version "1.10.+"
   id("net.nemerosa.versioning") version "3.0.0"
   id("org.gradle.signing")
 }
@@ -47,6 +46,15 @@ repositories {
       includeModule("com.terraformersmc", "modmenu")
     }
   }
+  exclusiveContent {
+    forRepository {
+      maven("https://repo.sleeping.town/")
+    }
+
+    filter {
+      includeModule("folk.sisby", "kaleido-config")
+    }
+  }
 }
 
 dependencies {
@@ -63,8 +71,7 @@ dependencies {
   modImplementation(include(fabricApi.module("fabric-api-base", "0.83.0+1.20"))!!)
   modImplementation(include(fabricApi.module("fabric-networking-api-v1", "0.83.0+1.20"))!!)
 
-  implementation(include("com.electronwill.night-config:core:3.6.6")!!)
-  implementation(include("com.electronwill.night-config:toml:3.6.6")!!)
+  implementation(include("folk.sisby:kaleido-config:0.3.3+1.3.2")!!)
 
   implementation("org.jetbrains:annotations:24.0.1")
   implementation("org.checkerframework:checker-qual:3.36.0")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=7c3ad722e9b0ce8205b91560fd6ce8296ac3eadf065672242fd73c06b8eeb6ee
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-all.zip
+distributionSha256Sum=8d97a97984f6cbd2b85fe4c60a743440a347544bf18818048e611f5288d46c94
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/dev/sapphic/couplings/Couplings.java
+++ b/src/main/java/dev/sapphic/couplings/Couplings.java
@@ -16,9 +16,6 @@
 
 package dev.sapphic.couplings;
 
-import com.electronwill.nightconfig.core.ConfigSpec;
-import com.electronwill.nightconfig.core.file.CommentedFileConfig;
-import com.electronwill.nightconfig.core.io.ParsingException;
 import com.google.common.base.Preconditions;
 import io.netty.buffer.Unpooled;
 import net.fabricmc.api.ModInitializer;
@@ -38,74 +35,33 @@ public final class Couplings implements ModInitializer {
   static final ResourceLocation CLIENT_CONFIG = new ResourceLocation("couplings", "client_config");
   static final ResourceLocation SERVER_CONFIG = new ResourceLocation("couplings", "server_config");
 
-  static final boolean IGNORE_SNEAKING;
-  static final boolean COUPLE_DOORS;
-  static final boolean COUPLE_FENCE_GATES;
-  static final boolean COUPLE_TRAPDOORS;
-
-  static {
-    final var configs = FabricLoader.getInstance().getConfigDir();
-    final var config = CommentedFileConfig.of(configs.resolve("couplings.toml"));
-
-    try { 
-      config.load();
-    } catch (final ParsingException e) {
-      LogManager.getLogger().warn(e.getMessage());
-    }
-
-    final var ignoreSneaking = "ignore_sneaking";
-    final var coupleDoors = "couple_doors";
-    final var coupleFenceGates = "couple_fence_gates";
-    final var coupleTrapdoors = "couple_trapdoors";
-
-    final var spec = new ConfigSpec();
-
-    spec.define(ignoreSneaking, true);
-    spec.define(coupleDoors, true);
-    spec.define(coupleFenceGates, true);
-    spec.define(coupleTrapdoors, true);
-
-    spec.correct(config);
-
-    config.setComment(ignoreSneaking, "Couple regardless of whether the player is sneaking");
-    config.setComment(coupleDoors, "Couple doors with opposing hinges");
-    config.setComment(coupleFenceGates, "Couple fence gates above and below on the same axis");
-    config.setComment(coupleTrapdoors, "Couple trapdoors along either sides and opposing");
-
-    config.save();
-
-    IGNORE_SNEAKING = config.get(ignoreSneaking);
-    COUPLE_DOORS = config.get(coupleDoors);
-    COUPLE_FENCE_GATES = config.get(coupleFenceGates);
-    COUPLE_TRAPDOORS = config.get(coupleTrapdoors);
-
-    if (!COUPLE_DOORS || !COUPLE_FENCE_GATES || !COUPLE_TRAPDOORS) {
-      LogManager.getLogger().warn("No features are enabled, this could be a bug!");
-    }
-  }
+  public static final CouplingsConfig CONFIG = CouplingsConfig.createToml(FabricLoader.getInstance().getConfigDir(), "", "couplings", CouplingsConfig.class);
 
   public static boolean ignoresSneaking(final Player player) {
     if (player instanceof CouplingsPlayer) {
       return CouplingsPlayer.ignoresSneaking(player);
     }
 
-    return IGNORE_SNEAKING;
+    return CONFIG.ignoreSneaking.value();
   }
 
   public static boolean couplesDoors(final Level level) {
-    return level.isClientSide() ? CouplingsClient.serverCouplesDoors() : COUPLE_DOORS;
+    return level.isClientSide() ? CouplingsClient.serverCouplesDoors() : CONFIG.coupleDoors.value();
   }
 
   public static boolean couplesFenceGates(final Level level) {
-    return level.isClientSide() ? CouplingsClient.serverCouplesFenceGates() : COUPLE_FENCE_GATES;
+    return level.isClientSide() ? CouplingsClient.serverCouplesFenceGates() : CONFIG.coupleFenceGates.value();
   }
 
   public static boolean couplesTrapdoors(final Level level) {
-    return level.isClientSide() ? CouplingsClient.serverCouplesTrapdoors() : COUPLE_TRAPDOORS;
+    return level.isClientSide() ? CouplingsClient.serverCouplesTrapdoors() : CONFIG.coupleTrapdoors.value();
   }
 
   @Override
   public void onInitialize() {
+    if (!CONFIG.coupleDoors.value() || !CONFIG.coupleFenceGates.value() || !CONFIG.coupleTrapdoors.value()) {
+      LogManager.getLogger().warn("No features are enabled, this could be a bug!");
+    }
     ServerPlayNetworking.registerGlobalReceiver(
         CLIENT_CONFIG,
         (server, player, listener, buf, sender) -> {
@@ -122,9 +78,9 @@ public final class Couplings implements ModInitializer {
         (listener, sender, server) -> {
           var couplings = 0b000;
 
-          couplings |= (COUPLE_DOORS ? 1 : 0) << 2;
-          couplings |= (COUPLE_FENCE_GATES ? 1 : 0) << 1;
-          couplings |= COUPLE_TRAPDOORS ? 1 : 0;
+          couplings |= (CONFIG.coupleDoors.value() ? 1 : 0) << 2;
+          couplings |= (CONFIG.coupleFenceGates.value() ? 1 : 0) << 1;
+          couplings |= CONFIG.coupleTrapdoors.value() ? 1 : 0;
 
           final var buffer =
               Unpooled.buffer(Byte.BYTES, Byte.BYTES).writeByte(couplings).asReadOnly();

--- a/src/main/java/dev/sapphic/couplings/CouplingsClient.java
+++ b/src/main/java/dev/sapphic/couplings/CouplingsClient.java
@@ -64,7 +64,7 @@ public final class CouplingsClient implements ClientModInitializer {
 
     ClientPlayConnectionEvents.JOIN.register(
         (listener, sender, minecraft) -> {
-          final var clientConfig = Couplings.IGNORE_SNEAKING ? 1 : 0;
+          final var clientConfig = Couplings.CONFIG.ignoreSneaking.value() ? 1 : 0;
 
           ClientPlayNetworking.send(
               Couplings.CLIENT_CONFIG,

--- a/src/main/java/dev/sapphic/couplings/CouplingsConfig.java
+++ b/src/main/java/dev/sapphic/couplings/CouplingsConfig.java
@@ -1,0 +1,19 @@
+package dev.sapphic.couplings;
+
+import folk.sisby.kaleido.api.ReflectiveConfig;
+import folk.sisby.kaleido.lib.quiltconfig.api.annotations.Comment;
+import folk.sisby.kaleido.lib.quiltconfig.api.annotations.SerializedNameConvention;
+import folk.sisby.kaleido.lib.quiltconfig.api.metadata.NamingSchemes;
+import folk.sisby.kaleido.lib.quiltconfig.api.values.TrackedValue;
+
+@SerializedNameConvention(NamingSchemes.SNAKE_CASE)
+public class CouplingsConfig extends ReflectiveConfig {
+    @Comment("Couple regardless of whether the player is sneaking")
+    public final TrackedValue<Boolean> ignoreSneaking = value(true);
+    @Comment("Couple doors with opposing hinges")
+    public final TrackedValue<Boolean>  coupleDoors = value(true);
+    @Comment("Couple fence gates above and below on the same axis")
+    public final TrackedValue<Boolean>  coupleFenceGates = value(true);
+    @Comment("Couple trapdoors along either sides and opposing")
+    public final TrackedValue<Boolean>  coupleTrapdoors = value(true);
+}


### PR DESCRIPTION
Closes #41, #44 in a weirder way.
Got tired of updating nightconfig every time a mod decided to break it via JIJ
[builds](https://github.com/sisby-folk/Couplings/releases/tag/kaleido-over-night) [kaleido](https://github.com/sisby-folk/kaleido-config)
before:
![notepad++_QsnV7qHANl](https://github.com/user-attachments/assets/53e2c931-0d5e-4c33-a9ca-3806ee4f8462)
after:
![image](https://github.com/user-attachments/assets/a3e7a7d1-6f11-4d15-a556-f53e810e4c97)
(the same, it's compatible)